### PR TITLE
Add val sorting commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,66 @@
 				"command": "valtown.diff",
 				"category": "Val Town",
 				"title": "Compare With Previous Version"
+			},
+			{
+				"command": "valtown.sortHomeByName",
+				"category": "Val Town",
+				"title": "Sort by Name"
+			},
+			{
+				"command": "valtown.sortHomeByPrivacy",
+				"category": "Val Town",
+				"title": "Sort by Privacy"
+			},
+			{
+				"command": "valtown.sortHomeByRun",
+				"category": "Val Town",
+				"title": "Sort by Last Run"
+			},
+			{
+				"command": "valtown.clearHomeSort",
+				"category": "Val Town",
+				"title": "Clear Sort"
+			},
+			{
+				"command": "valtown.sortLikedByName",
+				"category": "Val Town",
+				"title": "Sort by Name"
+			},
+			{
+				"command": "valtown.sortLikedByPrivacy",
+				"category": "Val Town",
+				"title": "Sort by Privacy"
+			},
+			{
+				"command": "valtown.sortLikedByRun",
+				"category": "Val Town",
+				"title": "Sort by Last Run"
+			},
+			{
+				"command": "valtown.clearLikedSort",
+				"category": "Val Town",
+				"title": "Clear Sort"
+			},
+			{
+				"command": "valtown.sortPinnedByName",
+				"category": "Val Town",
+				"title": "Sort by Name"
+			},
+			{
+				"command": "valtown.sortPinnedByPrivacy",
+				"category": "Val Town",
+				"title": "Sort by Privacy"
+			},
+			{
+				"command": "valtown.sortPinnedByRun",
+				"category": "Val Town",
+				"title": "Sort by Last Run"
+			},
+			{
+				"command": "valtown.clearPinnedSort",
+				"category": "Val Town",
+				"title": "Clear Sort"
 			}
 		],
 		"configuration": [
@@ -313,6 +373,66 @@
 					"command": "valtown.deleteVal",
 					"group": "navigation@8",
 					"when": "viewItem == val"
+				},
+				{
+					"command": "valtown.sortHomeByName",
+					"group": "home@1",
+					"when": "viewItem == home"
+				},
+				{
+					"command": "valtown.sortHomeByPrivacy",
+					"group": "home@2",
+					"when": "viewItem == home"
+				},
+				{
+					"command": "valtown.sortHomeByRun",
+					"group": "home@3",
+					"when": "viewItem == home"
+				},
+				{
+					"command": "valtown.clearHomeSort",
+					"group": "home@4",
+					"when": "viewItem == home"
+				},
+				{
+					"command": "valtown.sortLikedByName",
+					"group": "liked@1",
+					"when": "viewItem == likes"
+				},
+				{
+					"command": "valtown.sortLikedByPrivacy",
+					"group": "liked@2",
+					"when": "viewItem == likes"
+				},
+				{
+					"command": "valtown.sortLikedByRun",
+					"group": "liked@3",
+					"when": "viewItem == likes"
+				},
+				{
+					"command": "valtown.clearLikedSort",
+					"group": "liked@4",
+					"when": "viewItem == likes"
+				},
+				{
+					"command": "valtown.sortPinnedByName",
+					"group": "pinned@1",
+					"when": "viewItem == pinned"
+				},
+				{
+					"command": "valtown.sortPinnedByPrivacy",
+					"group": "pinned@2",
+					"when": "viewItem == pinned"
+				},
+				{
+					"command": "valtown.sortPinnedByRun",
+					"group": "pinned@3",
+					"when": "viewItem == pinned"
+				},
+				{
+					"command": "valtown.clearPinnedSort",
+					"group": "pinned@4",
+					"when": "viewItem == pinned"
 				}
 			],
 			"valtown.copy": [

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,269 +3,354 @@ import { clearToken, saveToken } from "./secrets";
 import { FullVal, ValtownClient } from "./client";
 import { valIcon } from "./tree";
 
-export function registerCommands(context: vscode.ExtensionContext, client: ValtownClient) {
-	function extractValID(arg: unknown) {
-		if (!arg) {
-			if (!(vscode.window.activeTextEditor?.document.uri.scheme === "val")) {
-				throw new Error("No val selected");
-			}
+export function registerCommands(
+  context: vscode.ExtensionContext,
+  client: ValtownClient
+) {
+  function extractValID(arg: unknown) {
+    if (!arg) {
+      if (!(vscode.window.activeTextEditor?.document.uri.scheme === "val")) {
+        throw new Error("No val selected");
+      }
 
-			return vscode.window.activeTextEditor?.document.uri.authority as string;
-		}
+      return vscode.window.activeTextEditor?.document.uri.authority as string;
+    }
 
-		if (typeof arg === "string") {
-			return arg;
-		}
+    if (typeof arg === "string") {
+      return arg;
+    }
 
-		if (typeof arg !== "object") {
-			throw new Error("Could not extract val ID");
-		}
+    if (typeof arg !== "object") {
+      throw new Error("Could not extract val ID");
+    }
 
-		if ("id" in arg && typeof arg.id === "string") {
-			return arg.id.split("/").pop() as string;
-		}
+    if ("id" in arg && typeof arg.id === "string") {
+      return arg.id.split("/").pop() as string;
+    }
 
-		if ("authority" in arg && typeof arg.authority === "string") {
-			return arg.authority as string;
-		}
+    if ("authority" in arg && typeof arg.authority === "string") {
+      return arg.authority as string;
+    }
 
-		throw new Error("Could not extract val ID");
-	}
+    throw new Error("Could not extract val ID");
+  }
 
-	context.subscriptions.push(
-		vscode.commands.registerCommand("valtown.setToken", async (token?: string) => {
-			if (!token) {
-				token = await vscode.window.showInputBox({
-					prompt: "ValTown Token",
-					placeHolder: "Token",
-					validateInput: async (value) => {
-						if (!value) {
-							return "Token cannot be empty"
-						}
-					}
-				});
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "valtown.setToken",
+      async (token?: string) => {
+        if (!token) {
+          token = await vscode.window.showInputBox({
+            prompt: "ValTown Token",
+            placeHolder: "Token",
+            validateInput: async (value) => {
+              if (!value) {
+                return "Token cannot be empty";
+              }
+            },
+          });
 
-				if (!token) {
-					return;
-				}
-			}
+          if (!token) {
+            return;
+          }
+        }
 
-			await saveToken(context, token);
-		}),
-		vscode.commands.registerCommand("valtown.clearToken", async () => {
-			await clearToken(context);
-		}),
+        await saveToken(context, token);
+      }
+    ),
+    vscode.commands.registerCommand("valtown.clearToken", async () => {
+      await clearToken(context);
+    }),
 
-		vscode.commands.registerCommand("valtown.createVal", async () => {
-			const val = await client.createVal();
+    vscode.commands.registerCommand("valtown.createVal", async () => {
+      const val = await client.createVal();
 
-			vscode.commands.executeCommand(
-				"vscode.open",
-				vscode.Uri.parse(
-					`val://${val.id}/${val.author?.username?.slice(1)}/${val.name}/mod.tsx`
-				)
-			);
+      vscode.commands.executeCommand(
+        "vscode.open",
+        vscode.Uri.parse(
+          `val://${val.id}/${val.author?.username?.slice(1)}/${
+            val.name
+          }/mod.tsx`
+        )
+      );
 
-			vscode.commands.executeCommand("valtown.refresh");
-		}),
-		vscode.commands.registerCommand("valtown.viewReadme", async (arg) => {
-			const valID = extractValID(arg)
-			const val = await client.getVal(valID);
-			vscode.commands.executeCommand(
-				"vscode.openWith",
-				vscode.Uri.parse(`val://${valID}/${val.author?.username?.slice(1)}/${val.name}/README.md`),
-				"vscode.markdown.preview.editor"
-			)
-		}),
-		vscode.commands.registerCommand("valtown.copyAsJSON", async (arg) => {
-			const valID = extractValID(arg);
-			const val = await client.getVal(valID);
-			vscode.env.clipboard.writeText(JSON.stringify(val, null, 2));
-		}),
-		vscode.commands.registerCommand("valtown.copyImport", async (arg) => {
-			const valID = extractValID(arg)
+      vscode.commands.executeCommand("valtown.refresh");
+    }),
 
-			const val = await client.getVal(valID);
-			vscode.env.clipboard.writeText(`import { ${val.name} } from "https://esm.town/v/${val.author.username.slice(1)}/${val.name}"`);
-			vscode.window.showInformationMessage(`Import statement copied to clipboard`);
-		}),
+    vscode.commands.registerCommand("valtown.sortHomeByName", async () => {
+      context.workspaceState.update("homeSortState", "name");
+      vscode.commands.executeCommand("valtown.refresh");
+    }),
+    vscode.commands.registerCommand("valtown.sortPinnedByName", async () => {
+      context.workspaceState.update("pinnedSortState", "name");
+      vscode.commands.executeCommand("valtown.refresh");
+    }),
+    vscode.commands.registerCommand("valtown.sortLikedByName", async () => {
+      context.workspaceState.update("likedSortState", "name");
+      vscode.commands.executeCommand("valtown.refresh");
+    }),
 
-		vscode.commands.registerCommand("valtown.copyID", async (arg) => {
-			const valID = extractValID(arg)
+    vscode.commands.registerCommand("valtown.sortHomeByPrivacy", async () => {
+      context.workspaceState.update("homeSortState", "privacy");
+      vscode.commands.executeCommand("valtown.refresh");
+    }),
+    vscode.commands.registerCommand("valtown.sortPinnedByPrivacy", async () => {
+      context.workspaceState.update("pinnedSortState", "privacy");
+      vscode.commands.executeCommand("valtown.refresh");
+    }),
+    vscode.commands.registerCommand("valtown.sortLikedByPrivacy", async () => {
+      context.workspaceState.update("likedSortState", "privacy");
+      vscode.commands.executeCommand("valtown.refresh");
+    }),
 
-			vscode.env.clipboard.writeText(valID);
-			vscode.window.showInformationMessage(`Val ID copied to clipboard`);
-		}),
+    vscode.commands.registerCommand("valtown.sortHomeByRun", async () => {
+      context.workspaceState.update("homeSortState", "run");
+      vscode.commands.executeCommand("valtown.refresh");
+    }),
+    vscode.commands.registerCommand("valtown.sortPinnedByRun", async () => {
+      context.workspaceState.update("pinnedSortState", "run");
+      vscode.commands.executeCommand("valtown.refresh");
+    }),
+    vscode.commands.registerCommand("valtown.sortLikedByRun", async () => {
+      context.workspaceState.update("likedSortState", "run");
+      vscode.commands.executeCommand("valtown.refresh");
+    }),
 
-		vscode.commands.registerCommand("valtown.copyRunEndpoint", async (arg) => {
-			const valID = extractValID(arg)
+    vscode.commands.registerCommand("valtown.clearHomeSort", async () => {
+      context.workspaceState.update("homeSortState", undefined);
+      vscode.commands.executeCommand("valtown.refresh");
+    }),
+    vscode.commands.registerCommand("valtown.clearPinnedSort", async () => {
+      context.workspaceState.update("pinnedSortState", undefined);
+      vscode.commands.executeCommand("valtown.refresh");
+    }),
+    vscode.commands.registerCommand("valtown.clearLikedSort", async () => {
+      context.workspaceState.update("likedSortState", undefined);
+      vscode.commands.executeCommand("valtown.refresh");
+    }),
 
-			const val = await client.getVal(valID);
-			vscode.env.clipboard.writeText(`https://api.val.town/v1/run/${val.author?.username?.slice(1)}.${val.name}`);
-			vscode.window.showInformationMessage(`Val run endpoint copied to clipboard`);
-		}),
-		vscode.commands.registerCommand("valtown.deleteVal", async (arg) => {
-			const valID = extractValID(arg)
+    vscode.commands.registerCommand("valtown.viewReadme", async (arg) => {
+      const valID = extractValID(arg);
+      const val = await client.getVal(valID);
+      vscode.commands.executeCommand(
+        "vscode.openWith",
+        vscode.Uri.parse(
+          `val://${valID}/${val.author?.username?.slice(1)}/${
+            val.name
+          }/README.md`
+        ),
+        "vscode.markdown.preview.editor"
+      );
+    }),
+    vscode.commands.registerCommand("valtown.copyAsJSON", async (arg) => {
+      const valID = extractValID(arg);
+      const val = await client.getVal(valID);
+      vscode.env.clipboard.writeText(JSON.stringify(val, null, 2));
+    }),
+    vscode.commands.registerCommand("valtown.copyImport", async (arg) => {
+      const valID = extractValID(arg);
 
-			await client.deleteVal(valID);
-			await vscode.commands.executeCommand("valtown.refresh");
-		}),
-		vscode.commands.registerCommand(
-			"valtown.openInBrowser",
-			async (arg) => {
-				const valID = extractValID(arg)
-				const val = await client.getVal(valID);
-				await vscode.env.openExternal(
-					vscode.Uri.parse(
-						`https://val.town/v/${val.author?.username?.slice(1)}/${val.name}`,
-					),
-				);
-			},
-		),
-		vscode.commands.registerCommand(
-			`valtown.copyWebEndpoint`,
-			async (arg) => {
-				const valID = extractValID(arg)
-				const val = await client.getVal(valID);
-				vscode.env.clipboard.writeText(
-					`https://${val.author?.username?.slice(1)}-${val.name}.web.val.run`,
-				);
-				vscode.window.showInformationMessage(`Val web endpoint copied to clipboard`);
-			},
-		),
-		vscode.commands.registerCommand(
-			`valtown.copyExpressEndpoint`,
-			async (arg) => {
-				const valID = extractValID(arg)
-				const val = await client.getVal(valID);
-				await vscode.env.clipboard.writeText(
-					`https://${val.author?.username?.slice(1)}-${val.name}.express.val.run`,
-				);
-				vscode.window.showInformationMessage(`Val express endpoint copied to clipboard`);
-			},
-		),
-		vscode.commands.registerCommand(
-			"valtown.copyLink",
-			async (arg) => {
-				const valID = extractValID(arg)
-				const val = await client.getVal(valID);
-				vscode.env.clipboard.writeText(
-					`https://val.town/v/${val.author?.username?.slice(1)}/${val.name}`,
-				);
-				vscode.window.showInformationMessage(`Val link copied to clipboard`);
-			},
-		),
-		vscode.commands.registerCommand(
-			"valtown.openLogs",
-			async (arg) => {
-				const valID = extractValID(arg)
-				const val = await client.getVal(valID);
-				await vscode.env.openExternal(
-					vscode.Uri.parse(
-						`https://val.town/v/${val.author?.username?.slice(1)}/${val.name}/evaluations`,
-					),
-				);
-			}),
-		vscode.commands.registerCommand(
-			"valtown.copyEmbed",
-			async (arg) => {
-				const valID = extractValID(arg)
-				const val = await client.getVal(valID);
-				vscode.env.clipboard.writeText(
-					`https://val.town/embed/${val.author?.username?.slice(1)}.${val.name}`,
-				);
-				vscode.window.showInformationMessage(`Val embed link copied to clipboard`);
-			},
-		),
-		vscode.commands.registerCommand(
-			"valtown.togglePinned",
-			async (arg) => {
-				const valID = extractValID(arg)
-				const val = await client.getVal(valID);
-				const pinnedVals = context.globalState.get<Record<string, FullVal>>("valtown.pins", {});
-				if (pinnedVals[valID]) {
-					delete pinnedVals[valID];
-				} else {
-					pinnedVals[valID] = val;
-				}
-				await context.globalState.update("valtown.pins", pinnedVals);
-				await vscode.commands.executeCommand("valtown.refresh");
-			},
-		),
-		vscode.commands.registerCommand(
-			"valtown.copyEmailAddress",
-			async (arg) => {
-				const valID = extractValID(arg)
-				const val = await client.getVal(valID);
-				await vscode.env.clipboard.writeText(`${val.author?.username?.slice(1)}.${val.name}@val.town`);
-				vscode.window.showInformationMessage(`Val email address copied to clipboard`);
-			},
-		),
-		vscode.commands.registerCommand(
-			"valtown.open",
-			async (arg) => {
-				const valID = extractValID(arg)
+      const val = await client.getVal(valID);
+      vscode.env.clipboard.writeText(
+        `import { ${
+          val.name
+        } } from "https://esm.town/v/${val.author.username.slice(1)}/${
+          val.name
+        }"`
+      );
+      vscode.window.showInformationMessage(
+        `Import statement copied to clipboard`
+      );
+    }),
 
-				const val = await client.getVal(valID);
-				return vscode.commands.executeCommand(
-					"vscode.open",
-					vscode.Uri.parse(
-						`val://${val.id}/${val.author?.username?.slice(1)}/${val.name}/mod.tsx`,
-					),
-				);
-			},
-		),
-		vscode.commands.registerCommand(
-			"valtown.diff",
-			async (arg) => {
-				const valID = extractValID(arg)
-				const val = await client.getVal(valID);
-				const versions = await client.listVersions(valID);
-				if (versions.length < 2) {
-					vscode.window.showErrorMessage("Val has no previous versions");
-					return;
-				}
-				const pick = await vscode.window.showQuickPick<{ version: number } & vscode.QuickPickItem>(
-					versions.slice(1).map((version) => ({
-						label: `v${version.version}`,
-						description: new Date(version.runStartAt).toLocaleString(),
-						version: version.version,
-					})),
-					{ title: "Select a version to open" },
-				);
-				if (!pick) {
-					return;
-				}
+    vscode.commands.registerCommand("valtown.copyID", async (arg) => {
+      const valID = extractValID(arg);
 
-				return vscode.commands.executeCommand(
-					"vscode.diff",
-					vscode.Uri.parse(`val://${val.id}/${val.author?.username?.slice(1)}/${val.name}@${pick.version}/mod.tsx`),
-					vscode.Uri.parse(`val://${val.id}/${val.author?.username?.slice(1)}/${val.name}@/mod.tsx`),
-				);
-			},
-		),
-		vscode.commands.registerCommand(
-			"valtown.quickOpen",
-			async () => {
-				const vals = await client.listMyVals();
-				const pick = await vscode.window.showQuickPick<{ id: string } & vscode.QuickPickItem>(
-					vals.map(val => ({
-						id: val.id,
-						label: `\$(${valIcon(val.privacy).id}) ${val.name}`,
-						description: `v${val.version}`
-					})), { title: "Select a val to open" })
-				if (!pick) {
-					return
-				}
+      vscode.env.clipboard.writeText(valID);
+      vscode.window.showInformationMessage(`Val ID copied to clipboard`);
+    }),
 
-				const val = await client.getVal(pick.id);
-				return vscode.commands.executeCommand(
-					"vscode.open",
-					vscode.Uri.parse(
-						`val://${val.id}/${val.author?.username?.slice(1)}/${val.name}/mod.tsx`,
-					),
-				);
-			},
-		),
-	)
+    vscode.commands.registerCommand("valtown.copyRunEndpoint", async (arg) => {
+      const valID = extractValID(arg);
+
+      const val = await client.getVal(valID);
+      vscode.env.clipboard.writeText(
+        `https://api.val.town/v1/run/${val.author?.username?.slice(1)}.${
+          val.name
+        }`
+      );
+      vscode.window.showInformationMessage(
+        `Val run endpoint copied to clipboard`
+      );
+    }),
+    vscode.commands.registerCommand("valtown.deleteVal", async (arg) => {
+      const valID = extractValID(arg);
+
+      await client.deleteVal(valID);
+      await vscode.commands.executeCommand("valtown.refresh");
+    }),
+    vscode.commands.registerCommand("valtown.openInBrowser", async (arg) => {
+      const valID = extractValID(arg);
+      const val = await client.getVal(valID);
+      await vscode.env.openExternal(
+        vscode.Uri.parse(
+          `https://val.town/v/${val.author?.username?.slice(1)}/${val.name}`
+        )
+      );
+    }),
+    vscode.commands.registerCommand(`valtown.copyWebEndpoint`, async (arg) => {
+      const valID = extractValID(arg);
+      const val = await client.getVal(valID);
+      vscode.env.clipboard.writeText(
+        `https://${val.author?.username?.slice(1)}-${val.name}.web.val.run`
+      );
+      vscode.window.showInformationMessage(
+        `Val web endpoint copied to clipboard`
+      );
+    }),
+    vscode.commands.registerCommand(
+      `valtown.copyExpressEndpoint`,
+      async (arg) => {
+        const valID = extractValID(arg);
+        const val = await client.getVal(valID);
+        await vscode.env.clipboard.writeText(
+          `https://${val.author?.username?.slice(1)}-${
+            val.name
+          }.express.val.run`
+        );
+        vscode.window.showInformationMessage(
+          `Val express endpoint copied to clipboard`
+        );
+      }
+    ),
+    vscode.commands.registerCommand("valtown.copyLink", async (arg) => {
+      const valID = extractValID(arg);
+      const val = await client.getVal(valID);
+      vscode.env.clipboard.writeText(
+        `https://val.town/v/${val.author?.username?.slice(1)}/${val.name}`
+      );
+      vscode.window.showInformationMessage(`Val link copied to clipboard`);
+    }),
+    vscode.commands.registerCommand("valtown.openLogs", async (arg) => {
+      const valID = extractValID(arg);
+      const val = await client.getVal(valID);
+      await vscode.env.openExternal(
+        vscode.Uri.parse(
+          `https://val.town/v/${val.author?.username?.slice(1)}/${
+            val.name
+          }/evaluations`
+        )
+      );
+    }),
+    vscode.commands.registerCommand("valtown.copyEmbed", async (arg) => {
+      const valID = extractValID(arg);
+      const val = await client.getVal(valID);
+      vscode.env.clipboard.writeText(
+        `https://val.town/embed/${val.author?.username?.slice(1)}.${val.name}`
+      );
+      vscode.window.showInformationMessage(
+        `Val embed link copied to clipboard`
+      );
+    }),
+    vscode.commands.registerCommand("valtown.togglePinned", async (arg) => {
+      const valID = extractValID(arg);
+      const val = await client.getVal(valID);
+      const pinnedVals = context.globalState.get<Record<string, FullVal>>(
+        "valtown.pins",
+        {}
+      );
+      if (pinnedVals[valID]) {
+        delete pinnedVals[valID];
+      } else {
+        pinnedVals[valID] = val;
+      }
+      await context.globalState.update("valtown.pins", pinnedVals);
+      await vscode.commands.executeCommand("valtown.refresh");
+    }),
+    vscode.commands.registerCommand("valtown.copyEmailAddress", async (arg) => {
+      const valID = extractValID(arg);
+      const val = await client.getVal(valID);
+      await vscode.env.clipboard.writeText(
+        `${val.author?.username?.slice(1)}.${val.name}@val.town`
+      );
+      vscode.window.showInformationMessage(
+        `Val email address copied to clipboard`
+      );
+    }),
+    vscode.commands.registerCommand("valtown.open", async (arg) => {
+      const valID = extractValID(arg);
+
+      const val = await client.getVal(valID);
+      return vscode.commands.executeCommand(
+        "vscode.open",
+        vscode.Uri.parse(
+          `val://${val.id}/${val.author?.username?.slice(1)}/${
+            val.name
+          }/mod.tsx`
+        )
+      );
+    }),
+    vscode.commands.registerCommand("valtown.diff", async (arg) => {
+      const valID = extractValID(arg);
+      const val = await client.getVal(valID);
+      const versions = await client.listVersions(valID);
+      if (versions.length < 2) {
+        vscode.window.showErrorMessage("Val has no previous versions");
+        return;
+      }
+      const pick = await vscode.window.showQuickPick<
+        { version: number } & vscode.QuickPickItem
+      >(
+        versions.slice(1).map((version) => ({
+          label: `v${version.version}`,
+          description: new Date(version.runStartAt).toLocaleString(),
+          version: version.version,
+        })),
+        { title: "Select a version to open" }
+      );
+      if (!pick) {
+        return;
+      }
+
+      return vscode.commands.executeCommand(
+        "vscode.diff",
+        vscode.Uri.parse(
+          `val://${val.id}/${val.author?.username?.slice(1)}/${val.name}@${
+            pick.version
+          }/mod.tsx`
+        ),
+        vscode.Uri.parse(
+          `val://${val.id}/${val.author?.username?.slice(1)}/${
+            val.name
+          }@/mod.tsx`
+        )
+      );
+    }),
+    vscode.commands.registerCommand("valtown.quickOpen", async () => {
+      const vals = await client.listMyVals();
+      const pick = await vscode.window.showQuickPick<
+        { id: string } & vscode.QuickPickItem
+      >(
+        vals.map((val) => ({
+          id: val.id,
+          label: `$(${valIcon(val.privacy).id}) ${val.name}`,
+          description: `v${val.version}`,
+        })),
+        { title: "Select a val to open" }
+      );
+      if (!pick) {
+        return;
+      }
+
+      const val = await client.getVal(pick.id);
+      return vscode.commands.executeCommand(
+        "vscode.open",
+        vscode.Uri.parse(
+          `val://${val.id}/${val.author?.username?.slice(1)}/${
+            val.name
+          }/mod.tsx`
+        )
+      );
+    })
+  );
 }

--- a/src/sortUtils.ts
+++ b/src/sortUtils.ts
@@ -1,0 +1,11 @@
+import { BaseVal } from "./client";
+
+const privacyOrder = { public: 0, unlisted: 1, private: 2 };
+
+export const sortFunctions: {
+  [key: string]: (a: BaseVal, b: BaseVal) => number;
+} = {
+  name: (a, b) => a.name.localeCompare(b.name),
+  privacy: (a, b) => privacyOrder[a.privacy] - privacyOrder[b.privacy],
+  run: (a, b) => b.runEndAt.localeCompare(a.runEndAt),
+};

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { BaseVal, FullVal, ValtownClient } from "./client";
-
+import { sortFunctions } from "./sortUtils";
 
 export function valIcon(privacy: "public" | "private" | "unlisted") {
   switch (privacy) {
@@ -14,12 +14,21 @@ export function valIcon(privacy: "public" | "private" | "unlisted") {
 }
 
 export class ValTownTreeView
-  implements vscode.TreeDataProvider<vscode.TreeItem> {
-  constructor(private client: ValtownClient) {
+  implements vscode.TreeDataProvider<vscode.TreeItem>
+{
+  constructor(
+    private context: vscode.ExtensionContext,
+    private client: ValtownClient
+  ) {
+    this.context = context;
   }
 
-  private _onDidChangeTreeData: vscode.EventEmitter<vscode.TreeItem | undefined | null | void> = new vscode.EventEmitter<vscode.TreeItem | undefined | null | void>();
-  readonly onDidChangeTreeData: vscode.Event<vscode.TreeItem | undefined | null | void> = this._onDidChangeTreeData.event;
+  private _onDidChangeTreeData: vscode.EventEmitter<
+    vscode.TreeItem | undefined | null | void
+  > = new vscode.EventEmitter<vscode.TreeItem | undefined | null | void>();
+  readonly onDidChangeTreeData: vscode.Event<
+    vscode.TreeItem | undefined | null | void
+  > = this._onDidChangeTreeData.event;
   public pins: FullVal[] = [];
 
   refresh() {
@@ -29,70 +38,102 @@ export class ValTownTreeView
   static valToTreeItem(val: BaseVal, prefix: string): vscode.TreeItem {
     const treeItem = new vscode.TreeItem(
       val.name,
-      vscode.TreeItemCollapsibleState.None,
+      vscode.TreeItemCollapsibleState.None
     );
     treeItem.id = `/${prefix}/${val.id}`;
-    treeItem.tooltip = `${val.author?.username}/${val.name}`
+    treeItem.tooltip = `${val.author?.username}/${val.name}`;
     treeItem.description = `v${val.version}`;
     treeItem.iconPath = valIcon(val.privacy);
     treeItem.contextValue = "val";
     treeItem.command = {
       command: "valtown.open",
       title: "Open Val",
-      arguments: [
-        { id: val.id },
-      ],
+      arguments: [{ id: val.id }],
     };
 
     return treeItem;
   }
 
-  async getChildren(
-    element?: vscode.TreeItem | undefined,
-  ) {
+  async getChildren(element?: vscode.TreeItem | undefined) {
     if (!this.client.authenticated) {
       return [];
     }
 
     if (!element) {
-      const sections = []
+      const sections = [];
+
       if (this.pins.length > 0) {
         const pinned = new vscode.TreeItem(
           "Pinned Vals",
-          this.pins.length > 0 ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.None,
-        )
+          this.pins.length > 0
+            ? vscode.TreeItemCollapsibleState.Expanded
+            : vscode.TreeItemCollapsibleState.None
+        );
+        pinned.contextValue = "pinned";
         pinned.iconPath = new vscode.ThemeIcon("pinned");
         sections.push(pinned);
       }
+
       const home = new vscode.TreeItem(
         "Home Vals",
-        vscode.TreeItemCollapsibleState.Expanded,
-      )
+        vscode.TreeItemCollapsibleState.Expanded
+      );
+      home.contextValue = "home";
       home.iconPath = new vscode.ThemeIcon("home");
       sections.push(home);
       const likes = new vscode.TreeItem(
         "Liked Vals",
-        vscode.TreeItemCollapsibleState.Collapsed,
-      )
+        vscode.TreeItemCollapsibleState.Collapsed
+      );
+      likes.contextValue = "likes";
       likes.iconPath = new vscode.ThemeIcon("heart");
       sections.push(likes);
+
       return sections;
     }
 
     switch (element.label) {
-      case "Pinned Vals":
-        return this.pins.map((val) => {
-          return ValTownTreeView.valToTreeItem(val, "pins");
-        });
+      case "Pinned Vals": {
+        const pinsSortOrder: string | undefined =
+          this.context.workspaceState.get("pinnedSortState");
+
+        if (pinsSortOrder !== undefined) {
+          const sortFunction = sortFunctions[pinsSortOrder];
+
+          if (sortFunction !== undefined) {
+            return this.pins
+              .sort(sortFunction)
+              .map((val) => ValTownTreeView.valToTreeItem(val, "pins"));
+          }
+        }
+
+        return this.pins.map((val) =>
+          ValTownTreeView.valToTreeItem(val, "pins")
+        );
+
+        // return this.pins.map((val) => {
+        //   return ValTownTreeView.valToTreeItem(val, "pins");
+        // });
+      }
       case "Home Vals": {
-        const vals = await this.client.listMyVals()
+        const vals = await this.client.listMyVals();
         if (!vals) {
           return [];
         }
 
-        return vals.map((val) => {
-          return ValTownTreeView.valToTreeItem(val, "home");
-        });
+        const homeSortOrder: string | undefined =
+          this.context.workspaceState.get("homeSortState");
+        if (homeSortOrder !== undefined) {
+          const sortFunction = sortFunctions[homeSortOrder];
+
+          if (sortFunction !== undefined) {
+            return vals
+              .sort(sortFunction)
+              .map((val) => ValTownTreeView.valToTreeItem(val, "home"));
+          }
+        }
+
+        return vals.map((val) => ValTownTreeView.valToTreeItem(val, "home"));
       }
       case "Liked Vals": {
         const vals = await this.client.listLikedVals();
@@ -100,9 +141,19 @@ export class ValTownTreeView
           return [];
         }
 
-        return vals.map((val) => {
-          return ValTownTreeView.valToTreeItem(val, "likes");
-        })
+        const likesSortOrder: string | undefined =
+          this.context.workspaceState.get("likedSortState");
+        if (likesSortOrder !== undefined) {
+          const sortFunction = sortFunctions[likesSortOrder];
+
+          if (sortFunction !== undefined) {
+            return vals
+              .sort(sortFunction)
+              .map((val) => ValTownTreeView.valToTreeItem(val, "home"));
+          }
+        }
+
+        return vals.map((val) => ValTownTreeView.valToTreeItem(val, "home"));
       }
       default:
         return [];
@@ -110,25 +161,42 @@ export class ValTownTreeView
   }
 
   getTreeItem(
-    element: vscode.TreeItem,
+    element: vscode.TreeItem
   ): vscode.TreeItem | Thenable<vscode.TreeItem> {
     return element;
   }
 }
 
-export async function registerTreeView(context: vscode.ExtensionContext, client: ValtownClient) {
-  const tree = new ValTownTreeView(client);
-  const pins = await context.globalState.get<Record<string, FullVal>>("valtown.pins", {});
+export async function registerTreeView(
+  context: vscode.ExtensionContext,
+  client: ValtownClient
+) {
+  context.workspaceState.update("homeSortState", undefined);
+  context.workspaceState.update("pinnedSortState", undefined);
+  context.workspaceState.update("likedSortState", undefined);
+
+  const tree = new ValTownTreeView(context, client);
+  const pins = await context.globalState.get<Record<string, FullVal>>(
+    "valtown.pins",
+    {}
+  );
   tree.pins = Object.values(pins);
-  context.subscriptions.push(vscode.window.createTreeView("valtown", {
-    treeDataProvider: tree,
-    showCollapseAll: true,
-  }))
 
-  context.subscriptions.push(vscode.commands.registerCommand("valtown.refresh", async () => {
-    const pins = await context.globalState.get<Record<string, FullVal>>("valtown.pins", {});
-    tree.pins = Object.values(pins);
-    tree.refresh();
-  }))
+  context.subscriptions.push(
+    vscode.window.createTreeView("valtown", {
+      treeDataProvider: tree,
+      showCollapseAll: true,
+    })
+  );
 
+  context.subscriptions.push(
+    vscode.commands.registerCommand("valtown.refresh", async () => {
+      const pins = await context.globalState.get<Record<string, FullVal>>(
+        "valtown.pins",
+        {}
+      );
+      tree.pins = Object.values(pins);
+      tree.refresh();
+    })
+  );
 }


### PR DESCRIPTION
This PR adds three commands for sorting vals:

- `Sort by name` (ascending alphabetical order)
- `Sort by privacy` (public > unlisted > private)
- `Sort by last run` (most recently run first)

There is also a `Clear sort` command. 

These commands are added to the main tree sections (`Home Vals`, `Pinned Vals`, `Liked Vals`). This allows for independent sorting of those sections. Because of this, I've had to duplicate each set of commands for each section. As far as I can tell, this is the only way to implement independent sorting. If there's a way to access the `treeItem.contextValue` within which a command is executed, that would allow simplification.